### PR TITLE
Add support for NPM beta releases

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,3 +4,6 @@ README.md
 jsr.json
 src/utils.ts
 tests/webhooks/verify.test.ts
+
+# Included to support npm publish --tag beta
+.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,11 @@ jobs:
       - name: Publish to npm
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm publish --access public
+          if [[ "${GITHUB_REF}" == *beta* ]]; then
+            npm publish --access public --tag beta
+          else
+            npm publish --access public
+          fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
This edits the `.github/workflows/release.yml` to support NPM beta releases.